### PR TITLE
Improve formatters

### DIFF
--- a/actions/pom.xml
+++ b/actions/pom.xml
@@ -23,11 +23,11 @@
     <parent>
         <groupId>tools.dynamia</groupId>
         <artifactId>tools.dynamia.parent</artifactId>
-        <version>5.4.3</version>
+        <version>5.4.4</version>
     </parent>
 
     <artifactId>tools.dynamia.actions</artifactId>
-    <version>5.4.3</version>
+    <version>5.4.4</version>
     <name>DynamiaTools - Actions</name>
     <url>https://dynamia.tools/docs/actions</url>
 
@@ -65,12 +65,12 @@
         <dependency>
             <groupId>tools.dynamia</groupId>
             <artifactId>tools.dynamia.integration</artifactId>
-            <version>5.4.3</version>
+            <version>5.4.4</version>
         </dependency>
         <dependency>
             <groupId>tools.dynamia</groupId>
             <artifactId>tools.dynamia.commons</artifactId>
-            <version>5.4.3</version>
+            <version>5.4.4</version>
         </dependency>
 
     </dependencies>

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -23,11 +23,11 @@
     <parent>
         <groupId>tools.dynamia</groupId>
         <artifactId>tools.dynamia.parent</artifactId>
-        <version>5.4.3</version>
+        <version>5.4.4</version>
     </parent>
 
     <artifactId>tools.dynamia.app</artifactId>
-    <version>5.4.3</version>
+    <version>5.4.4</version>
     <name>DynamiaTools - App</name>
     <url>https://dynamia.tools/docs/app</url>
 
@@ -74,58 +74,58 @@
         <dependency>
             <groupId>tools.dynamia</groupId>
             <artifactId>tools.dynamia.actions</artifactId>
-            <version>5.4.3</version>
+            <version>5.4.4</version>
         </dependency>
         <dependency>
             <groupId>tools.dynamia</groupId>
             <artifactId>tools.dynamia.commons</artifactId>
-            <version>5.4.3</version>
+            <version>5.4.4</version>
         </dependency>
         <dependency>
             <groupId>tools.dynamia</groupId>
             <artifactId>tools.dynamia.crud</artifactId>
-            <version>5.4.3</version>
+            <version>5.4.4</version>
         </dependency>
         <dependency>
             <groupId>tools.dynamia</groupId>
             <artifactId>tools.dynamia.domain</artifactId>
-            <version>5.4.3</version>
+            <version>5.4.4</version>
         </dependency>
         <dependency>
             <groupId>tools.dynamia</groupId>
             <artifactId>tools.dynamia.integration</artifactId>
-            <version>5.4.3</version>
+            <version>5.4.4</version>
         </dependency>
         <dependency>
             <groupId>tools.dynamia</groupId>
             <artifactId>tools.dynamia.io</artifactId>
-            <version>5.4.3</version>
+            <version>5.4.4</version>
         </dependency>
         <dependency>
             <groupId>tools.dynamia</groupId>
             <artifactId>tools.dynamia.navigation</artifactId>
-            <version>5.4.3</version>
+            <version>5.4.4</version>
         </dependency>
         <dependency>
             <groupId>tools.dynamia</groupId>
             <artifactId>tools.dynamia.reports</artifactId>
-            <version>5.4.3</version>
+            <version>5.4.4</version>
         </dependency>
         <dependency>
             <groupId>tools.dynamia</groupId>
             <artifactId>tools.dynamia.templates</artifactId>
-            <version>5.4.3</version>
+            <version>5.4.4</version>
         </dependency>
 
         <dependency>
             <groupId>tools.dynamia</groupId>
             <artifactId>tools.dynamia.viewers</artifactId>
-            <version>5.4.3</version>
+            <version>5.4.4</version>
         </dependency>
         <dependency>
             <groupId>tools.dynamia</groupId>
             <artifactId>tools.dynamia.web</artifactId>
-            <version>5.4.3</version>
+            <version>5.4.4</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.data</groupId>
@@ -208,7 +208,7 @@
         <dependency>
             <groupId>tools.dynamia</groupId>
             <artifactId>tools.dynamia.domain.jpa</artifactId>
-            <version>5.4.3</version>
+            <version>5.4.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -22,11 +22,11 @@
 
     <artifactId>tools.dynamia.commons</artifactId>
     <packaging>jar</packaging>
-    <version>5.4.3</version>
+    <version>5.4.4</version>
     <parent>
         <groupId>tools.dynamia</groupId>
         <artifactId>tools.dynamia.parent</artifactId>
-        <version>5.4.3</version>
+        <version>5.4.4</version>
     </parent>
     <name>DynamiaTools - Commons</name>
     <url>https://dynamia.tools/docs/common</url>

--- a/commons/src/main/java/tools/dynamia/commons/Formatters.java
+++ b/commons/src/main/java/tools/dynamia/commons/Formatters.java
@@ -20,54 +20,58 @@ import java.text.DateFormat;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
+import java.time.temporal.TemporalAccessor;
 import java.util.Date;
 
 
 /**
- * Basic formatters
+ * Utility class providing basic formatters for numbers, dates, times, and currencies.
+ * <p>
+ * All methods are static and use the default locale from {@link Messages#getDefaultLocale()}.
+ * </p>
  *
  * @author Mario A. Serrano Leones
  */
 public class Formatters {
 
-
     /**
-     * Format integer.
+     * Formats a number as an integer string using the default locale.
      *
-     * @param number the number
-     * @return the string
+     * @param number the number to format
+     * @return the formatted integer string
      */
     public static String formatInteger(Number number) {
         return NumberFormat.getIntegerInstance(Messages.getDefaultLocale()).format(number);
     }
 
     /**
-     * Format.
+     * Formats a number as a decimal string using the default locale.
      *
-     * @param number the number
-     * @return the string
+     * @param number the number to format
+     * @return the formatted decimal string
      */
     public static String formatDecimal(Number number) {
         return DecimalFormat.getInstance(Messages.getDefaultLocale()).format(number);
     }
 
     /**
-     * Format currency.
+     * Formats a number as a currency string using the default locale.
      *
-     * @param number the number
-     * @return the string
+     * @param number the number to format
+     * @return the formatted currency string
      */
     public static String formatCurrency(Number number) {
         return DecimalFormat.getCurrencyInstance(Messages.getDefaultLocale()).format(number);
     }
 
     /**
-     * Format currency without decimals.
+     * Formats a number as a currency string without decimals using the default locale.
      *
-     * @param number the number
-     * @return the string
+     * @param number the number to format
+     * @return the formatted currency string without decimals
      */
     public static String formatCurrencySimple(Number number) {
         var locale = Messages.getDefaultLocale();
@@ -77,39 +81,132 @@ public class Formatters {
     }
 
     /**
-     * Format a percent
+     * Formats a number as a percent string using the default locale.
      *
-     * @param number
-     * @return
+     * @param number the number to format
+     * @return the formatted percent string
      */
     public static String formatPercent(Number number) {
         return DecimalFormat.getPercentInstance(Messages.getDefaultLocale()).format(number);
     }
 
     /**
-     * @param date
-     * @return
+     * Formats a {@link Date} object as a date string using the default locale.
+     *
+     * @param date the date to format
+     * @return the formatted date string
      */
     public static String formatDate(Date date) {
         return DateFormat.getDateInstance(DateFormat.DEFAULT, Messages.getDefaultLocale()).format(date);
     }
 
     /**
-     * @param date
-     * @return
+     * Formats a {@link LocalDate} object as an ISO date string.
+     *
+     * @param date the local date to format
+     * @return the formatted ISO date string
      */
     public static String formatDate(LocalDate date) {
-        return date.format(DateTimeFormatter.ISO_DATE);
+        return date.format(DateTimeFormatter.ISO_LOCAL_DATE);
     }
 
     /**
-     * @param date
-     * @return
+     * Formats a {@link LocalTime} object as an ISO time string.
+     *
+     * @param localTime the local time to format
+     * @return the formatted ISO time string
      */
-    public static String formatTime(LocalTime date) {
-        return date.format(DateTimeFormatter.ISO_DATE);
+    public static String formatTime(LocalTime localTime) {
+        return localTime.format(DateTimeFormatter.ISO_LOCAL_TIME);
     }
 
+    /**
+     * Formats a {@link LocalDateTime} object as an ISO date-time string.
+     *
+     * @param localDateTime the local date-time to format
+     * @return the formatted ISO date-time string
+     */
+    public static String formatDateTime(LocalDateTime localDateTime) {
+        return localDateTime.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+    }
+
+    /**
+     * Formats a {@link LocalDate} object using a custom pattern.
+     *
+     * @param date    the local date to format
+     * @param pattern the pattern to use for formatting
+     * @return the formatted date string
+     */
+    public static String formatDate(LocalDate date, String pattern) {
+        return date.format(DateTimeFormatter.ofPattern(pattern)
+                .withLocale(Messages.getDefaultLocale())
+                .withZone(Messages.getDefaultTimeZone()));
+    }
+
+    /**
+     * Formats a {@link LocalTime} object using a custom pattern.
+     *
+     * @param localTime the local time to format
+     * @param pattern   the pattern to use for formatting
+     * @return the formatted time string
+     */
+    public static String formatTime(LocalTime localTime, String pattern) {
+        return localTime.format(DateTimeFormatter.ofPattern(pattern)
+                .withLocale(Messages.getDefaultLocale())
+                .withZone(Messages.getDefaultTimeZone()));
+    }
+
+    /**
+     * Formats a {@link LocalDateTime} object using a custom pattern.
+     *
+     * @param localDateTime the local date-time to format
+     * @param pattern       the pattern to use for formatting
+     * @return the formatted date-time string
+     */
+    public static String formatDateTime(LocalDateTime localDateTime, String pattern) {
+        return localDateTime.format(DateTimeFormatter.ofPattern(pattern)
+                .withLocale(Messages.getDefaultLocale())
+                .withZone(Messages.getDefaultTimeZone()));
+    }
+
+    /**
+     * Formats a {@link TemporalAccessor} object using a custom pattern.
+     *
+     * @param temporal the temporal accessor to format
+     * @param pattern  the pattern to use for formatting
+     * @return the formatted string
+     */
+    public static String formatTemporal(TemporalAccessor temporal, String pattern) {
+        return DateTimeFormatter.ofPattern(pattern)
+                .withLocale(Messages.getDefaultLocale())
+                .withZone(Messages.getDefaultTimeZone())
+                .format(temporal);
+    }
+
+    /**
+     * Formats a {@link Date} object using a custom pattern and the default locale.
+     *
+     * @param date    the date to format
+     * @param pattern the pattern to use for formatting
+     * @return the formatted date string
+     */
+    public static String formatDate(Date date, String pattern) {
+        if (date == null || pattern == null) {
+            return "";
+        }
+
+        var instant = DateTimeUtils.toInstant(date);
+        if (instant != null) {
+            return formatTemporal(instant.atZone(Messages.getDefaultTimeZone()), pattern);
+        } else {
+            return "";
+        }
+
+    }
+
+    /**
+     * Private constructor to prevent instantiation.
+     */
     private Formatters() {
     }
 }

--- a/commons/src/main/java/tools/dynamia/commons/Formatters.java
+++ b/commons/src/main/java/tools/dynamia/commons/Formatters.java
@@ -44,6 +44,9 @@ public class Formatters {
      * @return the formatted integer string
      */
     public static String formatInteger(Number number) {
+        if (number == null) {
+            return "";
+        }
         return NumberFormat.getIntegerInstance(Messages.getDefaultLocale()).format(number);
     }
 
@@ -54,6 +57,9 @@ public class Formatters {
      * @return the formatted decimal string
      */
     public static String formatDecimal(Number number) {
+        if (number == null) {
+            return "";
+        }
         return DecimalFormat.getInstance(Messages.getDefaultLocale()).format(number);
     }
 
@@ -64,6 +70,9 @@ public class Formatters {
      * @return the formatted currency string
      */
     public static String formatCurrency(Number number) {
+        if (number == null) {
+            return "";
+        }
         return DecimalFormat.getCurrencyInstance(Messages.getDefaultLocale()).format(number);
     }
 
@@ -74,6 +83,9 @@ public class Formatters {
      * @return the formatted currency string without decimals
      */
     public static String formatCurrencySimple(Number number) {
+        if (number == null) {
+            return "";
+        }
         var locale = Messages.getDefaultLocale();
         var formatter = NumberFormat.getCurrencyInstance(locale);
         formatter.setMaximumFractionDigits(0);
@@ -87,6 +99,9 @@ public class Formatters {
      * @return the formatted percent string
      */
     public static String formatPercent(Number number) {
+        if (number == null) {
+            return "";
+        }
         return DecimalFormat.getPercentInstance(Messages.getDefaultLocale()).format(number);
     }
 
@@ -97,6 +112,9 @@ public class Formatters {
      * @return the formatted date string
      */
     public static String formatDate(Date date) {
+        if (date == null) {
+            return "";
+        }
         return DateFormat.getDateInstance(DateFormat.DEFAULT, Messages.getDefaultLocale()).format(date);
     }
 
@@ -107,6 +125,9 @@ public class Formatters {
      * @return the formatted ISO date string
      */
     public static String formatDate(LocalDate date) {
+        if (date == null) {
+            return "";
+        }
         return date.format(DateTimeFormatter.ISO_LOCAL_DATE);
     }
 
@@ -117,6 +138,9 @@ public class Formatters {
      * @return the formatted ISO time string
      */
     public static String formatTime(LocalTime localTime) {
+        if (localTime == null) {
+            return "";
+        }
         return localTime.format(DateTimeFormatter.ISO_LOCAL_TIME);
     }
 
@@ -127,6 +151,9 @@ public class Formatters {
      * @return the formatted ISO date-time string
      */
     public static String formatDateTime(LocalDateTime localDateTime) {
+        if (localDateTime == null) {
+            return "";
+        }
         return localDateTime.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
     }
 
@@ -138,6 +165,9 @@ public class Formatters {
      * @return the formatted date string
      */
     public static String formatDate(LocalDate date, String pattern) {
+        if (date == null || pattern == null) {
+            return "";
+        }
         return date.format(DateTimeFormatter.ofPattern(pattern)
                 .withLocale(Messages.getDefaultLocale())
                 .withZone(Messages.getDefaultTimeZone()));
@@ -151,6 +181,9 @@ public class Formatters {
      * @return the formatted time string
      */
     public static String formatTime(LocalTime localTime, String pattern) {
+        if (localTime == null || pattern == null) {
+            return "";
+        }
         return localTime.format(DateTimeFormatter.ofPattern(pattern)
                 .withLocale(Messages.getDefaultLocale())
                 .withZone(Messages.getDefaultTimeZone()));
@@ -164,6 +197,9 @@ public class Formatters {
      * @return the formatted date-time string
      */
     public static String formatDateTime(LocalDateTime localDateTime, String pattern) {
+        if (localDateTime == null || pattern == null) {
+            return "";
+        }
         return localDateTime.format(DateTimeFormatter.ofPattern(pattern)
                 .withLocale(Messages.getDefaultLocale())
                 .withZone(Messages.getDefaultTimeZone()));
@@ -177,6 +213,9 @@ public class Formatters {
      * @return the formatted string
      */
     public static String formatTemporal(TemporalAccessor temporal, String pattern) {
+        if (temporal == null || pattern == null) {
+            return "";
+        }
         return DateTimeFormatter.ofPattern(pattern)
                 .withLocale(Messages.getDefaultLocale())
                 .withZone(Messages.getDefaultTimeZone())
@@ -194,14 +233,78 @@ public class Formatters {
         if (date == null || pattern == null) {
             return "";
         }
-
         var instant = DateTimeUtils.toInstant(date);
         if (instant != null) {
             return formatTemporal(instant.atZone(Messages.getDefaultTimeZone()), pattern);
         } else {
             return "";
         }
+    }
 
+    /**
+     * Formats a {@link LocalDate} object using a custom pattern, locale and zone.
+     *
+     * @param date the local date to format
+     * @param pattern the pattern to use for formatting
+     * @param locale the locale to use
+     * @param zoneId the zone id to use
+     * @return the formatted date string
+     */
+    public static String formatDate(LocalDate date, String pattern, java.util.Locale locale, java.time.ZoneId zoneId) {
+        if (date == null || pattern == null || locale == null || zoneId == null) {
+            return "";
+        }
+        return date.format(DateTimeFormatter.ofPattern(pattern).withLocale(locale).withZone(zoneId));
+    }
+
+    /**
+     * Formats a {@link LocalTime} object using a custom pattern, locale and zone.
+     *
+     * @param localTime the local time to format
+     * @param pattern the pattern to use for formatting
+     * @param locale the locale to use
+     * @param zoneId the zone id to use
+     * @return the formatted time string
+     */
+    public static String formatTime(LocalTime localTime, String pattern, java.util.Locale locale, java.time.ZoneId zoneId) {
+        if (localTime == null || pattern == null || locale == null || zoneId == null) {
+            return "";
+        }
+        return localTime.format(DateTimeFormatter.ofPattern(pattern).withLocale(locale).withZone(zoneId));
+    }
+
+    /**
+     * Formats a {@link LocalDateTime} object using a custom pattern, locale and zone.
+     *
+     * @param localDateTime the local date-time to format
+     * @param pattern the pattern to use for formatting
+     * @param locale the locale to use
+     * @param zoneId the zone id to use
+     * @return the formatted date-time string
+     */
+    public static String formatDateTime(LocalDateTime localDateTime, String pattern, java.util.Locale locale, java.time.ZoneId zoneId) {
+        if (localDateTime == null || pattern == null || locale == null || zoneId == null) {
+            return "";
+        }
+        return localDateTime.format(DateTimeFormatter.ofPattern(pattern).withLocale(locale).withZone(zoneId));
+    }
+
+    /**
+     * Formats a {@link Date} object using a custom pattern, locale and zone.
+     *
+     * @param date the date to format
+     * @param pattern the pattern to use for formatting
+     * @param locale the locale to use
+     * @param zoneId the zone id to use
+     * @return the formatted date string
+     */
+    public static String formatDate(Date date, String pattern, java.util.Locale locale, java.time.ZoneId zoneId) {
+        if (date == null || pattern == null || locale == null || zoneId == null) {
+            return "";
+        }
+        java.text.SimpleDateFormat sdf = new java.text.SimpleDateFormat(pattern, locale);
+        sdf.setTimeZone(java.util.TimeZone.getTimeZone(zoneId));
+        return sdf.format(date);
     }
 
     /**

--- a/commons/src/test/java/tools/dynamia/commons/FormattersTest.java
+++ b/commons/src/test/java/tools/dynamia/commons/FormattersTest.java
@@ -1,0 +1,127 @@
+package tools.dynamia.commons;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+
+public class FormattersTest {
+
+    @Before
+    public void setUp() throws Exception {
+        Locale.setDefault(Locale.US);
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+    }
+
+    @Test
+    public void testFormatInteger() {
+        assertEquals("1,234", Formatters.formatInteger(1234));
+        assertEquals("", Formatters.formatInteger(null));
+    }
+
+    @Test
+    public void testFormatDecimal() {
+        assertEquals("1,234.56", Formatters.formatDecimal(1234.56));
+        assertEquals("", Formatters.formatDecimal(null));
+    }
+
+    @Test
+    public void testFormatCurrency() {
+
+        assertTrue(Formatters.formatCurrency(1234.56).contains("1,234.56"));
+        assertEquals("", Formatters.formatCurrency(null));
+    }
+
+    @Test
+    public void testFormatCurrencySimple() {
+        assertTrue(Formatters.formatCurrencySimple(1234.56).contains("1,235"));
+        assertEquals("", Formatters.formatCurrencySimple(null));
+    }
+
+    @Test
+    public void testFormatPercent() {
+        assertTrue(Formatters.formatPercent(0.25).contains("25"));
+        assertEquals("", Formatters.formatPercent(null));
+    }
+
+    @Test
+    public void testFormatDateWithDate() throws ParseException {
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
+        Date date = sdf.parse("2023-09-05");
+        assertTrue(Formatters.formatDate(date).contains("2023"));
+        assertEquals("", Formatters.formatDate((Date) null));
+    }
+
+    @Test
+    public void testFormatDateWithLocalDate() {
+        LocalDate date = LocalDate.of(2023, 9, 5);
+        assertEquals("2023-09-05", Formatters.formatDate(date));
+        assertEquals("", Formatters.formatDate((LocalDate) null));
+    }
+
+    @Test
+    public void testFormatTimeWithLocalTime() {
+        LocalTime time = LocalTime.of(14, 30, 15);
+        assertEquals("14:30:15", Formatters.formatTime(time));
+        assertEquals("", Formatters.formatTime((LocalTime) null));
+    }
+
+    @Test
+    public void testFormatDateTimeWithLocalDateTime() {
+        LocalDateTime dt = LocalDateTime.of(2023, 9, 5, 14, 30, 15);
+        assertEquals("2023-09-05T14:30:15", Formatters.formatDateTime(dt));
+        assertEquals("", Formatters.formatDateTime((LocalDateTime) null));
+    }
+
+    @Test
+    public void testFormatDateWithLocalDateAndPattern() {
+        LocalDate date = LocalDate.of(2023, 9, 5);
+        assertEquals("05/09/2023", Formatters.formatDate(date, "dd/MM/yyyy"));
+        assertEquals("", Formatters.formatDate((LocalDate) null, "dd/MM/yyyy"));
+        assertEquals("", Formatters.formatDate(date, null));
+    }
+
+    @Test
+    public void testFormatTimeWithLocalTimeAndPattern() {
+        LocalTime time = LocalTime.of(14, 30, 15);
+        assertEquals("14:30", Formatters.formatTime(time, "HH:mm"));
+        assertEquals("", Formatters.formatTime(null, "HH:mm"));
+        assertEquals("", Formatters.formatTime(time, null));
+    }
+
+    @Test
+    public void testFormatDateTimeWithLocalDateTimeAndPattern() {
+        LocalDateTime dt = LocalDateTime.of(2023, 9, 5, 14, 30, 15);
+        assertEquals("05-09-2023 14:30", Formatters.formatDateTime(dt, "dd-MM-yyyy HH:mm"));
+        assertEquals("", Formatters.formatDateTime(null, "dd-MM-yyyy HH:mm"));
+        assertEquals("", Formatters.formatDateTime(dt, null));
+    }
+
+    @Test
+    public void testFormatTemporal() {
+        LocalDateTime dt = LocalDateTime.of(2023, 9, 5, 14, 30, 15);
+        assertEquals("2023/09/05", Formatters.formatTemporal(dt, "yyyy/MM/dd"));
+        assertEquals("", Formatters.formatTemporal(null, "yyyy/MM/dd"));
+        assertEquals("", Formatters.formatTemporal(dt, null));
+    }
+
+    @Test
+    public void testFormatDateWithDateAndPattern() throws ParseException {
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        Date date = sdf.parse("2023-09-05 14:30:15");
+        assertTrue(Formatters.formatDate(date, "dd/MM/yyyy HH:mm").startsWith("05/09/2023 14:30"));
+        assertEquals("", Formatters.formatDate((Date) null, "dd/MM/yyyy HH:mm"));
+        assertEquals("", Formatters.formatDate(date, null));
+    }
+}

--- a/crud/pom.xml
+++ b/crud/pom.xml
@@ -23,11 +23,11 @@
     <parent>
         <groupId>tools.dynamia</groupId>
         <artifactId>tools.dynamia.parent</artifactId>
-        <version>5.4.3</version>
+        <version>5.4.4</version>
     </parent>
 
     <artifactId>tools.dynamia.crud</artifactId>
-    <version>5.4.3</version>
+    <version>5.4.4</version>
     <name>DynamiaTools - CRUD</name>
     <url>https://dynamia.tools/docs/crud</url>
 
@@ -62,23 +62,23 @@
         <dependency>
             <groupId>tools.dynamia</groupId>
             <artifactId>tools.dynamia.actions</artifactId>
-            <version>5.4.3</version>
+            <version>5.4.4</version>
         </dependency>
         <dependency>
             <groupId>tools.dynamia</groupId>
             <artifactId>tools.dynamia.viewers</artifactId>
-            <version>5.4.3</version>
+            <version>5.4.4</version>
         </dependency>
 
         <dependency>
             <groupId>tools.dynamia</groupId>
             <artifactId>tools.dynamia.navigation</artifactId>
-            <version>5.4.3</version>
+            <version>5.4.4</version>
         </dependency>
         <dependency>
             <groupId>tools.dynamia</groupId>
             <artifactId>tools.dynamia.domain.jpa</artifactId>
-            <version>5.4.3</version>
+            <version>5.4.4</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/domain-jpa/pom.xml
+++ b/domain-jpa/pom.xml
@@ -23,13 +23,13 @@
     <parent>
         <groupId>tools.dynamia</groupId>
         <artifactId>tools.dynamia.parent</artifactId>
-        <version>5.4.3</version>
+        <version>5.4.4</version>
     </parent>
 
     <name>DynamiaTools - Domain JPA</name>
     <url>https://dynamia.tools/docs/domain</url>
     <artifactId>tools.dynamia.domain.jpa</artifactId>
-    <version>5.4.3</version>
+    <version>5.4.4</version>
     <packaging>jar</packaging>
 
     <licenses>

--- a/domain/pom.xml
+++ b/domain/pom.xml
@@ -21,13 +21,13 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>tools.dynamia.domain</artifactId>
-    <version>5.4.3</version>
+    <version>5.4.4</version>
     <packaging>jar</packaging>
 
     <parent>
         <groupId>tools.dynamia</groupId>
         <artifactId>tools.dynamia.parent</artifactId>
-        <version>5.4.3</version>
+        <version>5.4.4</version>
     </parent>
     <name>DynamiaTools - Domain</name>
     <url>https://dynamia.tools/docs/domain</url>

--- a/integration/pom.xml
+++ b/integration/pom.xml
@@ -27,12 +27,12 @@
     <parent>
         <groupId>tools.dynamia</groupId>
         <artifactId>tools.dynamia.parent</artifactId>
-        <version>5.4.3</version>
+        <version>5.4.4</version>
     </parent>
 
     <name>DynamiaTools - Integration</name>
     <description>A set of classes and interfaces that help integrate modules</description>
-    <version>5.4.3</version>
+    <version>5.4.4</version>
     <url>https://dynamia.tools/docs/integration</url>
 
     <licenses>

--- a/io/pom.xml
+++ b/io/pom.xml
@@ -28,11 +28,11 @@
     <parent>
         <groupId>tools.dynamia</groupId>
         <artifactId>tools.dynamia.parent</artifactId>
-        <version>5.4.3</version>
+        <version>5.4.4</version>
     </parent>
 
     <name>DynamiaTools - IO</name>
-    <version>5.4.3</version>
+    <version>5.4.4</version>
     <description>A set of classes and interfaces that help in any kind io task</description>
     <url>https://dynamia.tools/docs/io</url>
 

--- a/navigation/pom.xml
+++ b/navigation/pom.xml
@@ -23,11 +23,11 @@
     <parent>
         <groupId>tools.dynamia</groupId>
         <artifactId>tools.dynamia.parent</artifactId>
-        <version>5.4.3</version>
+        <version>5.4.4</version>
     </parent>
 
     <artifactId>tools.dynamia.navigation</artifactId>
-    <version>5.4.3</version>
+    <version>5.4.4</version>
     <name>DynamiaTools - Navigation</name>
     <url>https://dynamia.tools/docs/navigation</url>
 
@@ -63,17 +63,17 @@
         <dependency>
             <groupId>tools.dynamia</groupId>
             <artifactId>tools.dynamia.commons</artifactId>
-            <version>5.4.3</version>
+            <version>5.4.4</version>
         </dependency>
         <dependency>
             <groupId>tools.dynamia</groupId>
             <artifactId>tools.dynamia.integration</artifactId>
-            <version>5.4.3</version>
+            <version>5.4.4</version>
         </dependency>
         <dependency>
             <groupId>tools.dynamia</groupId>
             <artifactId>tools.dynamia.actions</artifactId>
-            <version>5.4.3</version>
+            <version>5.4.4</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>tools.dynamia</groupId>
     <artifactId>tools.dynamia.parent</artifactId>
-    <version>5.4.3</version>
+    <version>5.4.4</version>
     <packaging>pom</packaging>
     <organization>
         <name>Dynamia Soluciones IT SAS</name>

--- a/reports/pom.xml
+++ b/reports/pom.xml
@@ -26,11 +26,11 @@
     <parent>
         <groupId>tools.dynamia</groupId>
         <artifactId>tools.dynamia.parent</artifactId>
-        <version>5.4.3</version>
+        <version>5.4.4</version>
     </parent>
 
     <name>DynamiaTools - Reports</name>
-    <version>5.4.3</version>
+    <version>5.4.4</version>
     <description>A set of classes and interfaces that help building Reports</description>
     <url>https://dynamia.tools/docs/reports</url>
 

--- a/starter/pom.xml
+++ b/starter/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>tools.dynamia</groupId>
         <artifactId>tools.dynamia.parent</artifactId>
-        <version>5.4.3</version>
+        <version>5.4.4</version>
     </parent>
     <artifactId>dynamia-tools-starter</artifactId>
     <name>DynamiaTools - Starter</name>
@@ -26,17 +26,17 @@
         <dependency>
             <groupId>tools.dynamia</groupId>
             <artifactId>tools.dynamia.app</artifactId>
-            <version>5.4.3</version>
+            <version>5.4.4</version>
         </dependency>
         <dependency>
             <groupId>tools.dynamia</groupId>
             <artifactId>tools.dynamia.zk</artifactId>
-            <version>5.4.3</version>
+            <version>5.4.4</version>
         </dependency>
         <dependency>
             <groupId>tools.dynamia</groupId>
             <artifactId>tools.dynamia.domain.jpa</artifactId>
-            <version>5.4.3</version>
+            <version>5.4.4</version>
         </dependency>
         <dependency>
             <groupId>org.hibernate.validator</groupId>

--- a/templates/pom.xml
+++ b/templates/pom.xml
@@ -23,12 +23,12 @@
     <parent>
         <artifactId>tools.dynamia.parent</artifactId>
         <groupId>tools.dynamia</groupId>
-        <version>5.4.3</version>
+        <version>5.4.4</version>
     </parent>
 
 
     <artifactId>tools.dynamia.templates</artifactId>
-    <version>5.4.3</version>
+    <version>5.4.4</version>
     <name>DynamiaTools - Templates</name>
     <url>https://dynamia.tools/docs/templates</url>
 
@@ -64,12 +64,12 @@
         <dependency>
             <groupId>tools.dynamia</groupId>
             <artifactId>tools.dynamia.integration</artifactId>
-            <version>5.4.3</version>
+            <version>5.4.4</version>
         </dependency>
         <dependency>
             <groupId>tools.dynamia</groupId>
             <artifactId>tools.dynamia.commons</artifactId>
-            <version>5.4.3</version>
+            <version>5.4.4</version>
         </dependency>
     </dependencies>
 

--- a/ui/pom.xml
+++ b/ui/pom.xml
@@ -23,11 +23,11 @@
     <parent>
         <groupId>tools.dynamia</groupId>
         <artifactId>tools.dynamia.parent</artifactId>
-        <version>5.4.3</version>
+        <version>5.4.4</version>
     </parent>
 
     <artifactId>tools.dynamia.ui</artifactId>
-    <version>5.4.3</version>
+    <version>5.4.4</version>
     <name>DynamiaTools - UI</name>
     <url>https://dynamia.tools/docs/ui</url>
     <description>Helper classes for module integrations and messages</description>
@@ -64,17 +64,17 @@
         <dependency>
             <groupId>tools.dynamia</groupId>
             <artifactId>tools.dynamia.integration</artifactId>
-            <version>5.4.3</version>
+            <version>5.4.4</version>
         </dependency>
         <dependency>
             <groupId>tools.dynamia</groupId>
             <artifactId>tools.dynamia.commons</artifactId>
-            <version>5.4.3</version>
+            <version>5.4.4</version>
         </dependency>
         <dependency>
             <groupId>tools.dynamia</groupId>
             <artifactId>tools.dynamia.io</artifactId>
-            <version>5.4.3</version>
+            <version>5.4.4</version>
         </dependency>
     </dependencies>
 </project>

--- a/viewers/pom.xml
+++ b/viewers/pom.xml
@@ -23,13 +23,13 @@
 
     <artifactId>tools.dynamia.viewers</artifactId>
     <packaging>jar</packaging>
-    <version>5.4.3</version>
+    <version>5.4.4</version>
 
 
     <parent>
         <groupId>tools.dynamia</groupId>
         <artifactId>tools.dynamia.parent</artifactId>
-        <version>5.4.3</version>
+        <version>5.4.4</version>
     </parent>
 
     <name>DynamiaTools - Viewers</name>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -23,14 +23,14 @@
     <artifactId>tools.dynamia.web</artifactId>
     <packaging>jar</packaging>
 
-    <version>5.4.3</version>
+    <version>5.4.4</version>
     <description>A set of common classes and interfaces for web application development</description>
 
 
     <parent>
         <groupId>tools.dynamia</groupId>
         <artifactId>tools.dynamia.parent</artifactId>
-        <version>5.4.3</version>
+        <version>5.4.4</version>
     </parent>
 
     <name>DynamiaTools - Web</name>
@@ -88,27 +88,27 @@
         <dependency>
             <groupId>tools.dynamia</groupId>
             <artifactId>tools.dynamia.commons</artifactId>
-            <version>5.4.3</version>
+            <version>5.4.4</version>
         </dependency>
         <dependency>
             <groupId>tools.dynamia</groupId>
             <artifactId>tools.dynamia.integration</artifactId>
-            <version>5.4.3</version>
+            <version>5.4.4</version>
         </dependency>
         <dependency>
             <groupId>tools.dynamia</groupId>
             <artifactId>tools.dynamia.navigation</artifactId>
-            <version>5.4.3</version>
+            <version>5.4.4</version>
         </dependency>
         <dependency>
             <groupId>tools.dynamia</groupId>
             <artifactId>tools.dynamia.viewers</artifactId>
-            <version>5.4.3</version>
+            <version>5.4.4</version>
         </dependency>
         <dependency>
             <groupId>tools.dynamia</groupId>
             <artifactId>tools.dynamia.crud</artifactId>
-            <version>5.4.3</version>
+            <version>5.4.4</version>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>

--- a/zk/pom.xml
+++ b/zk/pom.xml
@@ -21,12 +21,12 @@
     <parent>
         <artifactId>tools.dynamia.parent</artifactId>
         <groupId>tools.dynamia</groupId>
-        <version>5.4.3</version>
+        <version>5.4.4</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>tools.dynamia.zk</artifactId>
-    <version>5.4.3</version>
+    <version>5.4.4</version>
     <packaging>jar</packaging>
     <name>DynamiaTools - ZK</name>
     <url>https://dynamia.tools/docs/zk</url>
@@ -99,31 +99,31 @@
         <dependency>
             <groupId>tools.dynamia</groupId>
             <artifactId>tools.dynamia.web</artifactId>
-            <version>5.4.3</version>
+            <version>5.4.4</version>
         </dependency>
 
         <dependency>
             <groupId>tools.dynamia</groupId>
             <artifactId>tools.dynamia.navigation</artifactId>
-            <version>5.4.3</version>
+            <version>5.4.4</version>
         </dependency>
 
         <dependency>
             <groupId>tools.dynamia</groupId>
             <artifactId>tools.dynamia.ui</artifactId>
-            <version>5.4.3</version>
+            <version>5.4.4</version>
         </dependency>
 
         <dependency>
             <groupId>tools.dynamia</groupId>
             <artifactId>tools.dynamia.domain</artifactId>
-            <version>5.4.3</version>
+            <version>5.4.4</version>
         </dependency>
 
         <dependency>
             <groupId>tools.dynamia</groupId>
             <artifactId>tools.dynamia.viewers</artifactId>
-            <version>5.4.3</version>
+            <version>5.4.4</version>
         </dependency>
         <dependency>
             <groupId>org.yaml</groupId>
@@ -134,19 +134,19 @@
         <dependency>
             <groupId>tools.dynamia</groupId>
             <artifactId>tools.dynamia.crud</artifactId>
-            <version>5.4.3</version>
+            <version>5.4.4</version>
         </dependency>
 
         <dependency>
             <groupId>tools.dynamia</groupId>
             <artifactId>tools.dynamia.reports</artifactId>
-            <version>5.4.3</version>
+            <version>5.4.4</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>tools.dynamia</groupId>
             <artifactId>tools.dynamia.templates</artifactId>
-            <version>5.4.3</version>
+            <version>5.4.4</version>
             <scope>compile</scope>
         </dependency>
 

--- a/zk/src/main/java/tools/dynamia/zk/converters/AbstractTemporalConverter.java
+++ b/zk/src/main/java/tools/dynamia/zk/converters/AbstractTemporalConverter.java
@@ -24,6 +24,7 @@ import tools.dynamia.commons.Messages;
 import tools.dynamia.commons.SimpleCache;
 import tools.dynamia.commons.logger.LoggingService;
 
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.format.FormatStyle;
 import java.time.temporal.TemporalAccessor;
@@ -31,6 +32,7 @@ import java.util.Date;
 import java.util.Locale;
 
 /**
+ *
  * @author Mario A. Serrano Leones
  */
 
@@ -61,24 +63,25 @@ public abstract class AbstractTemporalConverter implements Converter<Object, Obj
 
     private DateTimeFormatter loadFormatter() {
         Locale locale = Messages.getDefaultLocale();
+        ZoneId zoneId = Messages.getDefaultTimeZone();
         String pattern = getPattern();
         FormatStyle dateStyle = getDateStyle();
         FormatStyle timeStyle = getTimeStyle();
-        String key = pattern + "#" + locale.toString() + "#" + dateStyle + "#" + timeStyle;
-        return FORMATTER_SIMPLE_CACHE.getOrLoad(key, s -> buildFormatter(pattern, locale, dateStyle, timeStyle));
+        String key = pattern + "#" + locale.toString() + "#" + zoneId + "#" + dateStyle + "#" + timeStyle;
+        return FORMATTER_SIMPLE_CACHE.getOrLoad(key, s -> buildFormatter(pattern, locale, zoneId, dateStyle, timeStyle));
     }
 
-    protected DateTimeFormatter buildFormatter(String pattern, Locale locale, FormatStyle dateStyle, FormatStyle timeStyle) {
+    protected DateTimeFormatter buildFormatter(String pattern, Locale locale, ZoneId zoneId, FormatStyle dateStyle, FormatStyle timeStyle) {
         if (pattern != null && !pattern.isBlank()) {
-            return DateTimeFormatter.ofPattern(pattern, locale);
+            return DateTimeFormatter.ofPattern(pattern).withLocale(locale).withZone(zoneId);
         } else if (dateStyle != null && timeStyle != null) {
-            return DateTimeFormatter.ofLocalizedDateTime(dateStyle, timeStyle).withLocale(locale);
+            return DateTimeFormatter.ofLocalizedDateTime(dateStyle, timeStyle).withLocale(locale).withZone(zoneId);
         } else if (dateStyle != null && timeStyle == null) {
-            return DateTimeFormatter.ofLocalizedDate(dateStyle).withLocale(locale);
+            return DateTimeFormatter.ofLocalizedDate(dateStyle).withLocale(locale).withZone(zoneId);
         } else if (dateStyle == null && timeStyle != null) {
-            return DateTimeFormatter.ofLocalizedTime(timeStyle).withLocale(locale);
+            return DateTimeFormatter.ofLocalizedTime(timeStyle).withLocale(locale).withZone(zoneId);
         } else {
-            return DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").withLocale(locale);
+            return DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").withLocale(locale).withZone(zoneId);
         }
     }
 


### PR DESCRIPTION
This pull request updates the `Formatters` utility class in the `commons` module to provide more robust and flexible formatting for numbers, dates, and times, including support for null values and custom patterns/locales. It also adds comprehensive unit tests for this class. Additionally, the pull request bumps the version of all affected modules and their dependencies from `5.4.3` to `5.4.4` for consistency.

**Enhancements to formatting utilities:**

* Expanded and improved the `Formatters` class to support formatting of `LocalDate`, `LocalTime`, `LocalDateTime`, and `TemporalAccessor` with custom patterns, locales, and time zones, as well as adding null checks to return empty strings for null inputs.
* Updated JavaDoc comments and method signatures in `Formatters` for clarity and completeness.

**Testing improvements:**

* Added a new test class `FormattersTest` with comprehensive unit tests covering all formatting methods and edge cases (including null handling).

**Version updates for consistency:**

* Bumped the version from `5.4.3` to `5.4.4` in all affected `pom.xml` files and updated dependencies to use the new version across modules: `actions`, `app`, `commons`, `crud`, `domain`, and `domain-jpa`. [[1]](diffhunk://#diff-981db5f2ff2e83ef250d2018885430327ea813d67c481d428a8d43b1f2d97d9cL26-R30) [[2]](diffhunk://#diff-981db5f2ff2e83ef250d2018885430327ea813d67c481d428a8d43b1f2d97d9cL68-R73) [[3]](diffhunk://#diff-60207cd4ca681cf47fc17d43c1a59023f55500d53f6e7642d8d0fa59560a12f5L26-R30) [[4]](diffhunk://#diff-60207cd4ca681cf47fc17d43c1a59023f55500d53f6e7642d8d0fa59560a12f5L77-R128) [[5]](diffhunk://#diff-60207cd4ca681cf47fc17d43c1a59023f55500d53f6e7642d8d0fa59560a12f5L211-R211) [[6]](diffhunk://#diff-dc5eb976596c3b878ea91adfd9c404ecebfb9041c39a260203e2fdd45644e16cL25-R29) [[7]](diffhunk://#diff-3a248aef269d58b7a745b69b2cd782c54aeb1c318620c04135cd379c7a385c2bL26-R30) [[8]](diffhunk://#diff-3a248aef269d58b7a745b69b2cd782c54aeb1c318620c04135cd379c7a385c2bL65-R81) [[9]](diffhunk://#diff-027095366bad778445b95bf056e488de18fec8024c11dc19022b082b57ce480eL26-R32) [[10]](diffhunk://#diff-856b105fc6ab23ce78c22f31244ca594368dd8343c25edb61465c78e97fcb4e5L24-R30)